### PR TITLE
Reduced token usage input for the user and output from the chatbox; a…

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -39,7 +39,7 @@ Help students realize their time constraints through conversation and math, then
 
 ---
 
-## CRITICAL: You Always Start the Conversation
+## CRITICAL: You Always Start the Conversation, make your response for every text concise and to the point 
 
 After the student completes their survey, **YOU send the first message**. Make it personal by referencing their survey.
 
@@ -63,6 +63,8 @@ Use **motivational interviewing** and **Socratic questioning** BUT be directive 
 - Make specific suggestions: "I think X hours because Y"
 - Validate their feelings and struggles
 - Be honest but supportive about time realities
+- Be Concise, don't say anything unnecessary
+- Limit Token Usage as much as possible while still getting the crucial information in every output
 
 ---
 
@@ -256,7 +258,7 @@ How does this feel to you? If anything seems off or you want to adjust something
 
 **ONLY send this completion phrase when ALL of the following are true:**
 1. You have gathered ALL necessary information (classes, study hours, work, activities, etc.)
-2. You have provided a summary of the schedule you've built together
+2. You have provided a summary of the schedule you've built together. This summary needs to be concise and to the point, max 1000 characters for the summary
 3. The student has expressed satisfaction, agreement, or readiness (e.g., "sounds good", "yes", "let's do it", "that works", etc.)
 4. There are no outstanding questions or concerns
 
@@ -335,12 +337,13 @@ Continue the conversation naturally. Ask what they'd like to adjust, gather more
 - **Be realistic** - don't let them over-commit
 - **End with structure** - concrete weekly schedule in JSON
 - **Stay in character** - supportive peer mentor throughout
+- **Be Concise** - no filler
 
 Your ultimate goal: Help students create a realistic, sustainable schedule they actually believe in and will follow. Go Cougs!`
 }
 
 function createPostOnboardingPrompt(contextInfo: string) {
-  return `You are Fred, a friendly WSU academic success coach bot who helps students manage their ongoing academic life. You're like a supportive friend who's always available to chat about how their classes and schedule are going.
+  return `You are Fred, a friendly WSU academic success coach bot who helps students manage their ongoing academic life. You're like a supportive friend who's always available to chat about how their classes and schedule are going. keep your response output to less than 600 characters per response, only exception is the full summary which will be less than 1000 characters.
 
 ## STUDENT CONTEXT
 ${contextInfo}
@@ -504,6 +507,7 @@ export async function POST(req: Request) {
         hasSchedule: !!(schedule && Object.keys(schedule).length > 0),
         messageCount: messages.length,
         botName: 'Fred The Lion',
+      
       },
       posthogPrivacyMode: false,
     }),

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -210,9 +210,24 @@ export default function ScheduleApp() {
 
   // Chat auto-scroll functionality
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const [textareaHasOverflow, setTextareaHasOverflow] = useState(false) // UseState that toggles true/false when the send button moves a little when theres mutliple lines
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }
+
+  const handleTextareaInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setInputText(e.target.value)
+
+    // Check if textarea has overflowed to multiple lines
+    // ScrollHeight - Total height of every line in the textbox
+    // ClientHeight - Total VISIBLE height of every line in the textbox
+
+    if (textareaRef.current) {
+      const hasOverflow = textareaRef.current.scrollHeight > textareaRef.current.clientHeight
+      setTextareaHasOverflow(hasOverflow)
+    }
   }
 
   // Auto-scroll when messages change or loading state changes
@@ -952,8 +967,10 @@ export default function ScheduleApp() {
           <div className="flex items-end gap-2">
             <div className="flex flex-1 relative">
               <textarea
+                ref={textareaRef}
                 value={inputText}
-                onChange={(e) => setInputText(e.target.value)}
+                maxLength={300}
+                onChange={handleTextareaInput}
                 onKeyPress={handleKeyPress}
                 placeholder={
                   isLoading
@@ -968,7 +985,7 @@ export default function ScheduleApp() {
                 onClick={handleSendMessage}
                 disabled={!inputText.trim() || isLoading}
                 size="sm"
-                className="absolute right-2 bottom-2 h-8 w-8 p-0 rounded-full"
+                className={`absolute ${textareaHasOverflow ? 'right-5' : 'right-2'} bottom-2 h-8 w-8 p-0 rounded-full`}
               >
                 <Send className="h-4 w-4" />
               </Button>


### PR DESCRIPTION
I limited the user input length to at most 300 characters, which I think is on the generous side. Limiting the chatbot length was tricky, I sprinkled in the prompt to keep it concise and keep the response below 600 characters, with the full summary below 1000 characters. I tested it and it seems to be shorter on average compared to before. I also fixed a UI bug where the send button was overlapping the arrow keys in the user textbox. I just decided to move the send button to the side once the arrows appeared, so it looked cleaner.