### PR TITLE
Updated packages and supressed warning

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -471,7 +471,7 @@ if (lastUserMessage) {
 }
 
   // Convert messages to the format expected by AI SDK using the built-in converter
-  const coreMessages = convertToModelMessages(messages)
+  const coreMessages = await convertToModelMessages(messages)
 
   // Build context string for system prompt
   let contextInfo = ''

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
         <PostHogProvider>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { defineConfig, globalIgnores } from 'eslint/config'
+import nextVitals from 'eslint-config-next/core-web-vitals'
+import nextTs from 'eslint-config-next/typescript'
+
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  globalIgnores([
+    '.next/**',
+    'out/**',
+    'build/**',
+    'next-env.d.ts',
+  ]),
+])
+
+export default eslintConfig

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "target": "ES6",
     "skipLibCheck": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Changelog:
 Suppressed warning message "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used"

This was because HTML The layout rendered <html lang="en"> with no className or style, because the server doesn’t know the user’s theme. localStorage and prefers-color-scheme only exist in the browser, so the server will always render the default. The client then applies the real theme and the DOM will differ. That’s by design, not a bug.

Updated these packages:
AI & LLM
--------
ai                         5.0.93    -> 6.0.103
@ai-sdk/google             2.0.31    -> 3.0.33
@ai-sdk/react              2.0.93    -> 3.0.105
@google/genai              1.38.0    -> 1.43.0

ANALYTICS & OBSERVABILITY
--------------------------
posthog-js                 1.282.0   -> 1.356.0
posthog-node               5.15.0    -> 5.26.0
@posthog/ai                7.2.0     -> 7.9.3
@vercel/analytics          1.3.1     -> 1.6.1

FRAMEWORK & RUNTIME
--------------------
next                       14.2.25   -> 16.1.6
react                      19        -> 19.2.4
react-dom                  19        -> 19.2.4

DATABASE & STORAGE
------------------
@qdrant/js-client-rest     1.10.0    -> 1.17.0

UI COMPONENTS (RADIX)
----------------------
@radix-ui/react-accordion        1.2.2   -> 1.2.12
@radix-ui/react-alert-dialog     1.1.4   -> 1.1.15
@radix-ui/react-aspect-ratio     1.1.1   -> 1.1.8
@radix-ui/react-avatar           1.1.2   -> 1.1.11
@radix-ui/react-checkbox         1.1.3   -> 1.3.3
@radix-ui/react-collapsible      1.1.2   -> 1.1.12
@radix-ui/react-context-menu     2.2.4   -> 2.2.16
@radix-ui/react-dialog           1.1.4   -> 1.1.15
@radix-ui/react-dropdown-menu    2.1.4   -> 2.1.16
@radix-ui/react-hover-card       1.1.4   -> 1.1.15
@radix-ui/react-label            2.1.1   -> 2.1.8
@radix-ui/react-menubar          1.1.4   -> 1.1.16
@radix-ui/react-navigation-menu  1.2.3   -> 1.2.14
@radix-ui/react-popover          1.1.4   -> 1.1.15
@radix-ui/react-progress         1.1.1   -> 1.1.8
@radix-ui/react-radio-group      1.2.2   -> 1.3.8
@radix-ui/react-scroll-area      1.2.2   -> 1.2.10
@radix-ui/react-select           2.1.4   -> 2.2.6
@radix-ui/react-separator        1.1.1   -> 1.1.8
@radix-ui/react-slider           1.2.2   -> 1.3.6
@radix-ui/react-slot             1.1.1   -> 1.2.4
@radix-ui/react-switch           1.1.2   -> 1.2.6
@radix-ui/react-tabs             1.1.2   -> 1.1.13
@radix-ui/react-toast            1.2.4   -> 1.2.15
@radix-ui/react-toggle           1.1.1   -> 1.1.10
@radix-ui/react-toggle-group     1.1.1   -> 1.1.11
@radix-ui/react-tooltip          1.1.6   -> 1.2.8

UI UTILITIES & LIBRARIES
-------------------------
lucide-react               0.454.0   -> 0.575.0
geist                      1.3.1     -> 1.7.0
sonner                     1.7.4     -> 2.0.7
cmdk                       1.0.4     -> 1.1.1
vaul                       0.9.9     -> 1.1.2
recharts                   2.15.4    -> 3.7.0
embla-carousel-react       8.5.1     -> 8.6.0
input-otp                  1.4.1     -> 1.4.2
react-resizable-panels     2.1.7     -> 4.6.5
react-day-picker           9.8.0     -> 9.14.0

FORMS & VALIDATION
-------------------
react-hook-form            7.60.0    -> 7.71.2
@hookform/resolvers        3.10.0    -> 5.2.2
zod                        3.25.67   -> 4.3.6

STYLING
-------
tailwind-merge             3.3.1     -> 3.5.0
autoprefixer               10.4.20   -> 10.4.27

DEV DEPENDENCIES
----------------
typescript                 5         -> 5.9.3
eslint                     8         -> 9.25.1
eslint-config-next         15.5.4    -> 16.1.6
tailwindcss                4.1.9     -> 4.2.1
@tailwindcss/postcss       4.1.9     -> 4.2.1
postcss                    8.5       -> 8.5.6
tw-animate-css             1.3.3     -> 1.4.0
@types/node                22        -> 25.3.2
@types/react               18        -> 19.2.14
@types/react-dom           18        -> 19.2.3
@playwright/test           1.56.1    -> 1.58.2
@testing-library/react     16.3.0    -> 16.3.2
knip                       5.64.2    -> 5.85.0

REMOVED
-------
@google/generative-ai      0.24.1 (deps) / 0.11.0 (devDeps)  -> REMOVED
  - Replaced by @google/genai